### PR TITLE
Use env variables for Supabase config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables for the React app
+REACT_APP_SUPABASE_URL=YOUR_SUPABASE_URL
+REACT_APP_SUPABASE_KEY=YOUR_SUPABASE_ANON_KEY

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# hidrex-empleados
+# Hidrex Empleados
+
+React application to manage employees.
+
+## Setup
+
+1. Create a `.env` file by copying the provided example:
+   ```bash
+   cp .env.example .env
+   ```
+2. Edit `.env` and set `REACT_APP_SUPABASE_URL` and `REACT_APP_SUPABASE_KEY` with the credentials from your Supabase project.
+3. Install dependencies and start the development server:
+   ```bash
+   npm install
+   npm start
+   ```

--- a/src/supabaseClient.js
+++ b/src/supabaseClient.js
@@ -1,7 +1,7 @@
 import { createClient } from '@supabase/supabase-js'
 
-// REEMPLAZA ESTOS VALORES CON LOS DE TU PROYECTO SUPABASE
-const supabaseUrl = 'https://ywawglicmuzluplnxyxa.supabase.co'
-const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Inl3YXdnbGljbXV6bHVwbG54eXhhIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDgzNzA4NTYsImV4cCI6MjA2Mzk0Njg1Nn0.eaVhmm95dX-LijfG-tJ7UJ4gzFB5-95llXLtpTVs1c4'
+// Read Supabase credentials from environment variables
+const supabaseUrl = process.env.REACT_APP_SUPABASE_URL
+const supabaseKey = process.env.REACT_APP_SUPABASE_KEY
 
 export const supabase = createClient(supabaseUrl, supabaseKey)


### PR DESCRIPTION
## Summary
- load Supabase url/key from environment variables
- provide `.env.example` with placeholders
- document how to create `.env` before running the app

## Testing
- `npm run build` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden while fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_683f77ccb6bc8323964b59a1ccf78c56