### PR TITLE
Fix employee lookup by email

### DIFF
--- a/index.html
+++ b/index.html
@@ -483,7 +483,7 @@
                         const { data: employee, error: empError } = await supabase
                             .from('employees')
                             .select('*')
-                            .eq('email', session.user.email)
+                            .eq('email', session.user.email.toLowerCase())
                             .single();
                         
                         if (!empError && employee) {
@@ -533,7 +533,7 @@
                     const { data: employee, error } = await supabase
                         .from('employees')
                         .select('*')
-                        .eq('email', session.user.email)
+                        .eq('email', session.user.email.toLowerCase())
                         .single();
                     
                     if (error || !employee) {
@@ -572,7 +572,7 @@
                 const employeeData = {
                     name: formData.get('name'),
                     cedula: formData.get('cedula'),
-                    email: formData.get('email'),
+                    email: formData.get('email').toLowerCase(),
                     document_type: formData.get('document_type'),
                     position: formData.get('position'),
                     gender: formData.get('gender'),


### PR DESCRIPTION
## Summary
- ensure session email is lowercased when querying employees
- store employee emails in lowercase on save

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f7a15320883239380d0e766173cc0