### PR TITLE
Fix salary label initialization

### DIFF
--- a/index.html
+++ b/index.html
@@ -1702,7 +1702,6 @@
                         </form>
                     </div>
                 </div>
-                <script>updateSalaryLabel('${employee?.payment_type || 'mensual'}');</script>
             `;
         }
 
@@ -1984,6 +1983,9 @@
             `;
             
             lucide.createIcons();
+            if (appState.editingEmployee || appState.showAddEmployee) {
+                updateSalaryLabel(appState.editingEmployee?.payment_type || 'mensual');
+            }
         }
 
         // Inicializar la aplicación


### PR DESCRIPTION
## Summary
- ensure salary label is updated via JavaScript rather than an injected `<script>` tag

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f7bcdc05883239d301f08b8c44ed4