### PR TITLE
Add production instructions for index.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,38 @@ Tailwind CSS is compiled using PostCSS during the build process. Generate a prod
 ```bash
 npm run build
 ```
+
+## Serving `index.html` in Production
+
+There are two ways to deploy this project:
+
+### 1. React build
+
+1. Run `npm run build` to generate the production React bundle inside the
+   `build/` folder.
+2. Serve the `build/` directory with any static server or hosting provider.
+
+### 2. Plain HTML version
+
+The repository also includes a standalone `index.html` that does not use React
+bundling. To serve this file directly:
+
+1. Copy the runtime configuration:
+   ```bash
+   cp public/env.example.js env.js
+   ```
+   Place `env.js` next to `index.html` and edit it with your Supabase
+   credentials.
+2. Serve `index.html` (and the `env.js` file) with any static HTTP server.
+
+### Troubleshooting
+
+* **Missing `env.js`** &ndash; If the browser console shows
+  `window._env_ is undefined`, make sure `env.js` exists beside
+  `index.html` and defines `window._env_`.
+
+* **404 for `env.js`** &ndash; Verify that `env.js` was copied from
+  `public/env.example.js` to your production directory.
+
+The React build uses environment variables from `.env` at build time, whereas
+the plain HTML version reads its configuration at runtime from `env.js`.


### PR DESCRIPTION
## Summary
- document how to serve `index.html` in production
- clarify React build vs plain HTML
- add troubleshooting tips for missing `env.js`

## Testing
- `npm run build` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683f7e2221088323bead636ff6a81e39