### PR TITLE
Fix truncated JSX in calendar view

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -570,3 +570,32 @@ const VacationTrackingApp = () => {
               {days.map((day, index) => (
                 <button
                   key={index}
+                  onClick={() => toggleDateSelection(day)}
+                  disabled={!day}
+                  className={`p-2 text-sm rounded-lg ${
+                    !day
+                      ? 'invisible'
+                      : isDateSelected(day)
+                        ? 'bg-red-500 text-white'
+                        : 'bg-gray-100 hover:bg-gray-200'
+                  }`}
+                >
+                  {day || ''}
+                </button>
+              ))}
+            </div>
+
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4">
+      {/* Main interface placeholder */}
+    </div>
+  );
+};
+
+export default VacationTrackingApp;


### PR DESCRIPTION
## Summary
- close the calendar component by mapping days to buttons and closing JSX
- add a placeholder return for the main interface

## Testing
- `npm start` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f85f324cc8323be32a00b807e0667